### PR TITLE
feat: :sparkles: allow subscribers to post email and name

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2069,6 +2069,7 @@ version = "0.1.0"
 dependencies = [
  "actix-web",
  "reqwest",
+ "serde",
  "tokio",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ name = "zero2prod"
 
 [dependencies]
 actix-web = "4"
+serde = { version="1", features = ["derive"] }
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 
 [dev-dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,10 +11,22 @@ async fn health_check() -> impl Responder {
     HttpResponse::Ok().finish()
 }
 
+#[allow(dead_code)]
+#[derive(serde::Deserialize)]
+struct FormData {
+    email: String,
+    name: String,
+}
+
+async fn subscribe(_form: web::Form<FormData>) -> HttpResponse {
+    HttpResponse::Ok().finish()
+}
+
 pub fn run(listener: TcpListener) -> Result<Server, std::io::Error> {
     let server = HttpServer::new(|| {
         App::new()
             .route("/health_check", web::get().to(health_check))
+            .route("/subscriptions", web::post().to(subscribe))
             .route("/", web::get().to(greet))
             .route("/{name}", web::get().to(greet))
     })

--- a/tests/health_check.rs
+++ b/tests/health_check.rs
@@ -1,5 +1,13 @@
 use std::net::TcpListener;
 
+fn spawn_app() -> String {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("Failed to bind random port.");
+    let port = listener.local_addr().unwrap().port();
+    let server = zero2prod::run(listener).expect("Failed to bind address.");
+    let _ = tokio::spawn(server);
+    format!("http://127.0.0.1:{}", port)
+}
+
 #[tokio::test]
 async fn health_check_works() {
     let address = spawn_app();
@@ -15,10 +23,66 @@ async fn health_check_works() {
     assert_eq!(Some(0), response.content_length())
 }
 
-fn spawn_app() -> String {
-    let listener = TcpListener::bind("127.0.0.1:0").expect("Failed to bind random port.");
-    let port = listener.local_addr().unwrap().port();
-    let server = zero2prod::run(listener).expect("Failed to bind address.");
-    let _ = tokio::spawn(server);
-    format!("http://127.0.0.1:{}", port)
+#[tokio::test]
+async fn subscribe_returns_a_200_when_form_data_valid_and_have_extra_fields() {
+    let app_address = spawn_app();
+    let client = reqwest::Client::new();
+
+    let body = "this_field_is_extra=True&name=le%20guin&email=ursula_le_guin%40gmail.com";
+    let response = client
+        .post(&format!("{}/subscriptions", app_address))
+        .header("Content-Type", "application/x-www-form-urlencoded")
+        .body(body)
+        .send()
+        .await
+        .expect("Failed to execute request.");
+
+    assert_eq!(200, response.status().as_u16())
+}
+
+#[tokio::test]
+async fn subscribe_returns_a_200_when_form_data_valid() {
+    let app_address = spawn_app();
+    let client = reqwest::Client::new();
+
+    let body = "name=le%20guin&email=ursula_le_guin%40gmail.com";
+    let response = client
+        .post(&format!("{}/subscriptions", app_address))
+        .header("Content-Type", "application/x-www-form-urlencoded")
+        .body(body)
+        .send()
+        .await
+        .expect("Failed to execute request.");
+
+    assert_eq!(200, response.status().as_u16())
+}
+
+#[tokio::test]
+async fn subscribe_returns_a_400_when_form_data_missing() {
+    let app_address = spawn_app();
+    let client = reqwest::Client::new();
+
+    let test_cases = vec![
+        ("name=le%20guin", "email field is missing"),
+        ("email=ursula_le_guin%40gmail.com", "name field is missing"),
+        ("", "both name and email fields are missing"),
+    ];
+
+    for (invalid_body, error_message) in test_cases {
+        let response = client
+            .post(&format!("{}/subscriptions", app_address))
+            .header("Content-Type", "application/x-www-form-urlencoded")
+            .body(invalid_body)
+            .send()
+            .await
+            .expect("Failed to execute request.");
+
+        assert_eq!(
+            400,
+            response.status().as_u16(),
+            // Additional customised error message on test failure
+            "The API did not fail with 400 Bad Request when the payload was {}.",
+            error_message
+        );
+    }
 }


### PR DESCRIPTION
Add enpoint for subscribers, takes an email and a name as "application/x-www-form-urlencoded" data.

Right now it just drops them straight on the floor. We do at least 400 if the required fields are missing